### PR TITLE
make prod deploy a separate thing that has to be invoked manually (for now)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,26 +86,18 @@ node {
             timeout(time: 15, unit: 'MINUTES') {
                input id: 'deploy', message: "Check status here:  https://jira.adeo.no/browse/${deploy}"
             }
+             slackSend([
+                 color: 'good',
+                 message: "${application} version ${releaseVersion} has been deployed to pre-prod."
+             ])
          } catch (Exception ex) {
+             slackSend([
+                 color: 'danger',
+                 message: "Unable to deploy ${application} version ${releaseVersion} to pre-prod. See https://jira.adeo.no/browse/${deploy} for details"
+             ])
             throw new Exception("Deploy feilet :( \n Se https://jira.adeo.no/browse/" + deploy + " for detaljer", ex)
          }
       }
-   }
-
-   stage('Deploy to Prod') {
-       timeout(time: 5, unit: 'MINUTES') {
-           input id: 'prod', message: "Deploy to prod?"
-       }
-
-       callback = "${env.BUILD_URL}input/Deploy/"
-       def deploy = deployLib.deployNaisApp(application, releaseVersion, 'p', zone, namespace, callback, committer).key
-       try {
-           timeout(time: 15, unit: 'MINUTES') {
-               input id: 'deploy', message: "Check status here:  https://jira.adeo.no/browse/${deploy}"
-           }
-       } catch (Exception e) {
-           throw new Exception("Deploy feilet :( \n Se https://jira.adeo.no/browse/" + deploy + " for detaljer", e)
-       }
    }
 
    stage("Tag") {

--- a/JenkinsfileDeployToProd
+++ b/JenkinsfileDeployToProd
@@ -1,0 +1,36 @@
+@Library('deploy')
+import deploy
+
+def deployLib = new deploy()
+
+node {
+   def application = "fpsoknad-oppslag"
+   def version
+   def zone = 'fss'
+   def namespace = 'default'
+
+   stage('Deploy to Prod') {
+       version = ${env.version}
+       callback = "${env.BUILD_URL}input/Deploy/"
+       def deploy = deployLib.deployNaisApp(application, version, 'p', zone, namespace, callback, "Jenkins").key
+       try {
+           timeout(time: 15, unit: 'MINUTES') {
+               input id: 'deploy', message: "Check status here:  https://jira.adeo.no/browse/${deploy}"
+           }
+           slackSend([
+               color: 'good',
+               message: "${application} version ${version} has been deployed to production."
+           ])
+       } catch (Exception ex) {
+           slackSend([
+               color: 'danger',
+               message: "Unable to deploy ${application} version ${version} to production. See https://jira.adeo.no/browse/${deploy} for details"
+           ])
+           throw new Exception("Deploy failed :( \n See https://jira.adeo.no/browse/" + deploy + " for details", ex)
+       }
+   }
+
+}
+
+
+


### PR DESCRIPTION
Vad tycks? Det tagges etter deploy til preprod, og det må lages en egen Jenkins-jobb for prod